### PR TITLE
Fix import of CAPI RSA keys.

### DIFF
--- a/src/PCLCrypto.Android/RsaAsymmetricKeyAlgorithmProvider.cs
+++ b/src/PCLCrypto.Android/RsaAsymmetricKeyAlgorithmProvider.cs
@@ -81,12 +81,12 @@ namespace PCLCrypto
             IPrivateKey privateKey;
             IPublicKey publicKey;
 
-            var spec = new RSAPrivateKeySpec(new BigInteger(parameters.Modulus), new BigInteger(parameters.D));
+            var spec = new RSAPrivateKeySpec(new BigInteger(1, parameters.Modulus), new BigInteger(1, parameters.D));
             var factory = KeyFactory.GetInstance("RSA");
             privateKey = factory.GeneratePrivate(spec);
 
             var privateRsaKey = privateKey.JavaCast<IRSAPrivateKey>();
-            var publicKeySpec = new RSAPublicKeySpec(privateRsaKey.Modulus, new BigInteger(parameters.Exponent));
+            var publicKeySpec = new RSAPublicKeySpec(privateRsaKey.Modulus, new BigInteger(1, parameters.Exponent));
             publicKey = factory.GeneratePublic(publicKeySpec);
 
             return new RsaCryptographicKey(publicKey, privateKey, parameters, this.algorithm);
@@ -98,7 +98,7 @@ namespace PCLCrypto
             Requires.NotNull(keyBlob, "keyBlob");
 
             var parameters = KeyFormatter.GetFormatter(blobType).Read(keyBlob);
-            var spec = new RSAPublicKeySpec(new BigInteger(parameters.Modulus), new BigInteger(parameters.Exponent));
+            var spec = new RSAPublicKeySpec(new BigInteger(1, parameters.Modulus), new BigInteger(1, parameters.Exponent));
             KeyFactory factory = KeyFactory.GetInstance("RSA");
             IPublicKey publicKey = factory.GeneratePublic(spec);
             return new RsaCryptographicKey(publicKey, parameters, this.algorithm);

--- a/src/PCLCrypto.Tests.Shared/AsymmetricKeyAlgorithmProviderTests.cs
+++ b/src/PCLCrypto.Tests.Shared/AsymmetricKeyAlgorithmProviderTests.cs
@@ -151,6 +151,9 @@
                     byte[] key2Blob = key2.ExportPublicKey(format);
 
                     CollectionAssertEx.AreEqual(keyBlob, key2Blob);
+
+                    WinRTCrypto.CryptographicEngine.Encrypt(key2, new byte[0]);
+
                     Debug.WriteLine("Format {0} supported.", format);
                     Debug.WriteLine(Convert.ToBase64String(keyBlob));
                     supportedFormats++;


### PR DESCRIPTION
BigIntegers must be positive for RSAPublicKeySpec. Therefore add a leading zero byte in the case the most significant bit is set.

I was not able to import RSA public keys created on a Windows desktop client into an Android key. After some debugging I found that Modulus and Exponent are correctly received at the Android site but that the native key creation fails. I am not sure, but may be that your tires around KeyFormatter and removing/adding leading zeros are now obsolete.

I hope will merge this...

Thanks for your work!

Regards,
Thomas.