### PR TITLE
Improve symmetric encryption streaming in WinRT

### DIFF
--- a/src/PCLCrypto.Android/SymmetricCryptographicKey.cs
+++ b/src/PCLCrypto.Android/SymmetricCryptographicKey.cs
@@ -89,9 +89,9 @@ namespace PCLCrypto
             this.InitializeCipher(CipherMode.EncryptMode, iv, ref this.encryptingCipher);
             Requires.Argument(paddingInUse || this.IsValidInputSize(data.Length), "data", "Length does not a multiple of block size and no padding is selected.");
 
-            return this.Padding != SymmetricAlgorithmPadding.None
-                ? this.encryptingCipher.DoFinal(data)
-                : this.encryptingCipher.Update(data);
+            return this.CanStreamAcrossTopLevelCipherOperations
+                ? this.encryptingCipher.Update(data)
+                : this.encryptingCipher.DoFinal(data);
         }
 
         /// <inheritdoc />
@@ -104,9 +104,9 @@ namespace PCLCrypto
 
             try
             {
-                return this.Padding != SymmetricAlgorithmPadding.None
-                    ? this.decryptingCipher.DoFinal(data)
-                    : this.decryptingCipher.Update(data);
+                return this.CanStreamAcrossTopLevelCipherOperations
+                    ? this.encryptingCipher.Update(data)
+                    : this.encryptingCipher.DoFinal(data);
             }
             catch (IllegalBlockSizeException ex)
             {
@@ -195,7 +195,7 @@ namespace PCLCrypto
                     newCipher = true;
                 }
 
-                if (iv != null || this.Padding != SymmetricAlgorithmPadding.None || newCipher)
+                if (iv != null || !this.CanStreamAcrossTopLevelCipherOperations || newCipher)
                 {
                     iv = this.ThisOrDefaultIV(iv);
                     using (var ivspec = iv != null ? new IvParameterSpec(iv) : null)

--- a/src/PCLCrypto.Android/SymmetricCryptographicKey.cs
+++ b/src/PCLCrypto.Android/SymmetricCryptographicKey.cs
@@ -105,8 +105,8 @@ namespace PCLCrypto
             try
             {
                 return this.CanStreamAcrossTopLevelCipherOperations
-                    ? this.encryptingCipher.Update(data)
-                    : this.encryptingCipher.DoFinal(data);
+                    ? this.decryptingCipher.Update(data)
+                    : this.decryptingCipher.DoFinal(data);
             }
             catch (IllegalBlockSizeException ex)
             {

--- a/src/PCLCrypto.Android/SymmetricCryptographicKey.cs
+++ b/src/PCLCrypto.Android/SymmetricCryptographicKey.cs
@@ -89,7 +89,7 @@ namespace PCLCrypto
             this.InitializeCipher(CipherMode.EncryptMode, iv, ref this.encryptingCipher);
             Requires.Argument(paddingInUse || this.IsValidInputSize(data.Length), "data", "Length does not a multiple of block size and no padding is selected.");
 
-            return this.Mode.IsBlockCipher()
+            return this.Padding != SymmetricAlgorithmPadding.None
                 ? this.encryptingCipher.DoFinal(data)
                 : this.encryptingCipher.Update(data);
         }
@@ -104,7 +104,7 @@ namespace PCLCrypto
 
             try
             {
-                return this.Mode.IsBlockCipher()
+                return this.Padding != SymmetricAlgorithmPadding.None
                     ? this.decryptingCipher.DoFinal(data)
                     : this.decryptingCipher.Update(data);
             }
@@ -175,29 +175,6 @@ namespace PCLCrypto
         }
 
         /// <summary>
-        /// Initializes a new cipher.
-        /// </summary>
-        /// <param name="mode">The mode.</param>
-        /// <param name="iv">The initialization vector to use.</param>
-        /// <returns>
-        /// The initialized cipher.
-        /// </returns>
-        private Cipher GetInitializedCipher(CipherMode mode, byte[] iv)
-        {
-            switch (mode)
-            {
-                case CipherMode.DecryptMode:
-                    this.InitializeCipher(mode, iv, ref this.decryptingCipher);
-                    return this.decryptingCipher;
-                case CipherMode.EncryptMode:
-                    this.InitializeCipher(mode, iv, ref this.encryptingCipher);
-                    return this.encryptingCipher;
-                default:
-                    throw new ArgumentException();
-            }
-        }
-
-        /// <summary>
         /// Initializes the cipher if it has not yet been initialized.
         /// </summary>
         /// <param name="mode">The mode.</param>
@@ -218,7 +195,7 @@ namespace PCLCrypto
                     newCipher = true;
                 }
 
-                if (this.Mode.IsBlockCipher() || newCipher)
+                if (iv != null || this.Padding != SymmetricAlgorithmPadding.None || newCipher)
                 {
                     iv = this.ThisOrDefaultIV(iv);
                     using (var ivspec = iv != null ? new IvParameterSpec(iv) : null)

--- a/src/PCLCrypto.Shared.Common/SymmetricAlgorithmExtensions.cs
+++ b/src/PCLCrypto.Shared.Common/SymmetricAlgorithmExtensions.cs
@@ -29,6 +29,14 @@ namespace PCLCrypto
         public static bool IsBlockCipher(this SymmetricAlgorithmMode mode) => mode != SymmetricAlgorithmMode.Streaming;
 
         /// <summary>
+        /// Gets a value indicating whether the specified mode offers authentication.
+        /// </summary>
+        /// <param name="mode">The mode to check.</param>
+        /// <returns><c>true</c> if the cipher is an authenticating block mode cipher; <c>false</c> otherwise.</returns>
+        public static bool IsAuthenticated(this SymmetricAlgorithmMode mode)
+            => mode == SymmetricAlgorithmMode.Gcm || mode == SymmetricAlgorithmMode.Ccm;
+
+        /// <summary>
         /// Returns a platform-specific algorithm that conforms to the prescribed platform-neutral algorithm.
         /// </summary>
         /// <param name="algorithm">The PCL algorithm.</param>

--- a/src/PCLCrypto.Shared.Common/SymmetricAlgorithmMode.cs
+++ b/src/PCLCrypto.Shared.Common/SymmetricAlgorithmMode.cs
@@ -24,12 +24,14 @@ namespace PCLCrypto
         Ecb,
 
         /// <summary>
-        /// The CCM mode.
+        /// Counter with CBC-MAC.
+        /// It is an authenticated encryption algorithm designed to provide both authentication and confidentiality. CCM mode is only defined for block ciphers with a block length of 128 bits.
         /// </summary>
         Ccm,
 
         /// <summary>
-        /// The GCM mode.
+        /// Galois/Counter Mode.
+        /// An authenticated encryption algorithm designed to provide both data authenticity (integrity) and confidentiality. GCM is defined for block ciphers with a block size of 128 bits.
         /// </summary>
         Gcm,
     }

--- a/src/PCLCrypto.Shared.NetFxSymmetric/SymmetricCryptographicKey.cs
+++ b/src/PCLCrypto.Shared.NetFxSymmetric/SymmetricCryptographicKey.cs
@@ -22,6 +22,16 @@ namespace PCLCrypto
         private readonly Platform.SymmetricAlgorithm algorithm;
 
         /// <summary>
+        /// The transform used for the last encryption algorithm.
+        /// </summary>
+        private Platform.ICryptoTransform encryptor;
+
+        /// <summary>
+        /// The transform used for the last decryption algorithm.
+        /// </summary>
+        private Platform.ICryptoTransform decryptor;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="SymmetricCryptographicKey"/> class.
         /// </summary>
         /// <param name="algorithm">The algorithm, initialized with the key.</param>
@@ -58,6 +68,9 @@ namespace PCLCrypto
         /// <inheritdoc />
         public void Dispose()
         {
+            this.encryptor?.Dispose();
+            this.decryptor?.Dispose();
+
             var disposable = this.algorithm as IDisposable;
             if (disposable != null)
             {
@@ -72,16 +85,23 @@ namespace PCLCrypto
             Requires.Argument(paddingInUse || this.IsValidInputSize(data.Length), "data", "Length does not a multiple of block size and no padding is selected.");
             Requires.Argument(iv == null || this.Mode.UsesIV(), "iv", "IV supplied but does not apply to this cipher.");
 
-            var encryptor = this.algorithm.CreateEncryptor(this.algorithm.Key, this.ThisOrDefaultIV(iv));
-            return encryptor.TransformFinalBlock(data, 0, data.Length);
+            return this.CipherOperation(
+                ref this.encryptor,
+                (me, initVector) => me.algorithm.CreateEncryptor(me.algorithm.Key, me.ThisOrDefaultIV(initVector)),
+                data,
+                iv);
         }
 
         /// <inheritdoc />
         protected internal override byte[] Decrypt(byte[] data, byte[] iv)
         {
             Requires.Argument(this.IsValidInputSize(data.Length), "data", "Length does not a multiple of block size and no padding is selected.");
-            var decryptor = this.algorithm.CreateDecryptor(this.algorithm.Key, this.ThisOrDefaultIV(iv));
-            return decryptor.TransformFinalBlock(data, 0, data.Length);
+
+            return this.CipherOperation(
+                ref this.decryptor,
+                (me, initVector) => me.algorithm.CreateDecryptor(me.algorithm.Key, me.ThisOrDefaultIV(initVector)),
+                data,
+                iv);
         }
 
         /// <inheritdoc />
@@ -128,6 +148,37 @@ namespace PCLCrypto
         private bool IsValidInputSize(int lengthInBytes)
         {
             return lengthInBytes > 0 && (lengthInBytes * 8) % this.algorithm.BlockSize == 0;
+        }
+
+        /// <summary>
+        /// Transforms an input block.
+        /// </summary>
+        /// <param name="transformField">Either the <see cref="encryptor"/> or <see cref="decryptor"/> field.</param>
+        /// <param name="transformCreator">The function to create a new transformer.</param>
+        /// <param name="data">The input data.</param>
+        /// <param name="iv">The initialization vector.</param>
+        /// <returns>The result of the transform.</returns>
+        private byte[] CipherOperation(ref Platform.ICryptoTransform transformField, Func<SymmetricCryptographicKey, byte[], Platform.ICryptoTransform> transformCreator, byte[] data, byte[] iv)
+        {
+            Requires.NotNull(transformCreator, nameof(transformCreator));
+
+            if (iv != null || this.Padding != SymmetricAlgorithmPadding.None || transformField == null)
+            {
+                transformField?.Dispose();
+                transformField = transformCreator(this, iv);
+            }
+
+            if (this.Padding == SymmetricAlgorithmPadding.None)
+            {
+                byte[] outputBlock = new byte[data.Length];
+                int bytesOutput = transformField.TransformBlock(data, 0, data.Length, outputBlock, 0);
+                Array.Resize(ref outputBlock, bytesOutput);
+                return outputBlock;
+            }
+            else
+            {
+                return transformField.TransformFinalBlock(data, 0, data.Length);
+            }
         }
 
         /// <summary>

--- a/src/PCLCrypto.Shared.NetFxSymmetric/SymmetricCryptographicKey.cs
+++ b/src/PCLCrypto.Shared.NetFxSymmetric/SymmetricCryptographicKey.cs
@@ -162,13 +162,13 @@ namespace PCLCrypto
         {
             Requires.NotNull(transformCreator, nameof(transformCreator));
 
-            if (iv != null || this.Padding != SymmetricAlgorithmPadding.None || transformField == null)
+            if (iv != null || !this.CanStreamAcrossTopLevelCipherOperations || transformField == null)
             {
                 transformField?.Dispose();
                 transformField = transformCreator(this, iv);
             }
 
-            if (this.Padding == SymmetricAlgorithmPadding.None)
+            if (this.CanStreamAcrossTopLevelCipherOperations)
             {
                 byte[] outputBlock = new byte[data.Length];
                 int bytesOutput = transformField.TransformBlock(data, 0, data.Length, outputBlock, 0);

--- a/src/PCLCrypto.Shared.NetFxSymmetric/SymmetricKeyAlgorithmProvider.cs
+++ b/src/PCLCrypto.Shared.NetFxSymmetric/SymmetricKeyAlgorithmProvider.cs
@@ -111,7 +111,7 @@ namespace PCLCrypto
         /// </returns>
         private Platform.SymmetricAlgorithm GetAlgorithm()
         {
-#if SILVERLIGHT || __IOS__
+#if SILVERLIGHT
             if (this.Name == SymmetricAlgorithmName.Aes &&
                 this.Mode == SymmetricAlgorithmMode.Cbc &&
                 this.Padding == SymmetricAlgorithmPadding.PKCS7)
@@ -123,7 +123,15 @@ namespace PCLCrypto
                 throw new NotSupportedException();
             }
 #else
-            var platform = Platform.SymmetricAlgorithm.Create(this.Name.GetString());
+            Platform.SymmetricAlgorithm platform = null;
+#if __IOS__
+            if (this.Name == SymmetricAlgorithmName.Aes)
+            {
+                platform = new Platform.AesManaged();
+            }
+#else
+            platform = Platform.SymmetricAlgorithm.Create(this.Name.GetString());
+#endif
             if (platform == null)
             {
                 throw new NotSupportedException();

--- a/src/PCLCrypto.Shared.PlatformCommon/SymmetricCryptographicKey.Shared.cs
+++ b/src/PCLCrypto.Shared.PlatformCommon/SymmetricCryptographicKey.Shared.cs
@@ -22,5 +22,12 @@ namespace PCLCrypto
         /// Gets the padding used by this instance.
         /// </summary>
         public SymmetricAlgorithmPadding Padding { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether multiple calls to encrypt/decrypt a block size
+        /// input is equivalent to the same operation but with all the input at once.
+        /// </summary>
+        private bool CanStreamAcrossTopLevelCipherOperations
+            => this.Padding == SymmetricAlgorithmPadding.None && !this.Mode.IsAuthenticated();
     }
 }

--- a/src/PCLCrypto.Tests.Android/PCLCrypto.Tests.Android.csproj
+++ b/src/PCLCrypto.Tests.Android/PCLCrypto.Tests.Android.csproj
@@ -16,7 +16,7 @@
     <AndroidApplication>true</AndroidApplication>
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
-    <AndroidUseLatestPlatformSdk>True</AndroidUseLatestPlatformSdk>
+    <AndroidUseLatestPlatformSdk>False</AndroidUseLatestPlatformSdk>
     <TargetFrameworkVersion>v5.0</TargetFrameworkVersion>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <NonShipping>true</NonShipping>

--- a/src/PCLCrypto.Tests.Shared/CryptographicEngineTests.cs
+++ b/src/PCLCrypto.Tests.Shared/CryptographicEngineTests.cs
@@ -16,6 +16,12 @@ public class CryptographicEngineTests
     private const string AesKeyMaterial = "T1kMUiju2rHiRyhJKfo/Jg==";
     private const string DataAesCiphertextBase64 = "3ChRgsiJ0mXxJIEQS5Z4NA==";
 
+#if SILVERLIGHT
+    private const string SkipIfOnlyStandardAESSupported = "Only standard AES is supported.";
+#else
+    private const string SkipIfOnlyStandardAESSupported = null;
+#endif
+
     /// <summary>
     /// Data the fits within a single cryptographic block.
     /// </summary>
@@ -210,7 +216,7 @@ public class CryptographicEngineTests
         }
     }
 
-    [Fact]
+    [Fact(Skip = SkipIfOnlyStandardAESSupported)]
     public void KeyStateResetIfAndOnlyIfInitVectorIsSupplied()
     {
         this.KeyStateResetIfAndOnlyIfInitVectorIsSupplied(WinRTCrypto.CryptographicEngine.Encrypt);

--- a/src/PCLCrypto.Tests.Shared/CryptographicEngineTests.cs
+++ b/src/PCLCrypto.Tests.Shared/CryptographicEngineTests.cs
@@ -218,6 +218,21 @@ public class CryptographicEngineTests
     }
 
     [Fact]
+    public void KeyStateResetWithNullIVWhenPaddingIsPresent()
+    {
+        var algorithm = WinRTCrypto.SymmetricKeyAlgorithmProvider.OpenAlgorithm(SymmetricAlgorithm.AesCbcPkcs7);
+        var data = WinRTCrypto.CryptographicBuffer.GenerateRandom((uint)algorithm.BlockLength);
+        var key = algorithm.CreateSymmetricKey(Convert.FromBase64String(AesKeyMaterial));
+
+        // When padding is used, the key always resets state for each operation,
+        // even when IV is null.
+        byte[] cipherText1 = WinRTCrypto.CryptographicEngine.Encrypt(key, data, null);
+        byte[] cipherText2 = WinRTCrypto.CryptographicEngine.Encrypt(key, data, null);
+
+        Assert.Equal<byte>(cipherText1, cipherText2);
+    }
+
+    [Fact]
     public void CreateEncryptor_SymmetricEncryptionEquivalence()
     {
         foreach (SymmetricAlgorithm symmetricAlgorithm in Enum.GetValues(typeof(SymmetricAlgorithm)))


### PR DESCRIPTION
WinRT allows within certain constraints for multiple successive calls to `CryptographicEngine.Encrypt` to behave the same as one single call with all the data at once. In particular, when not using padding and when the block mode does not offer authentication, the subsequent calls to `Encrypt` can pass `null` as the IV, and use the same instance of `ICryptographicKey` in order to keep the stream going.

This fixes `WinRTCrypto` to emulate that behavior across other platforms and adds tests to lock the behavior in place.