### PR TITLE
Fix test failures on Android 6

### DIFF
--- a/src/PCLCrypto.Android/SymmetricCryptographicKey.cs
+++ b/src/PCLCrypto.Android/SymmetricCryptographicKey.cs
@@ -236,7 +236,7 @@ namespace PCLCrypto
                 bool newCipher = false;
                 if (cipher == null)
                 {
-                    cipher = Cipher.GetInstance(this.GetCipherAcquisitionName().ToString());
+                    cipher = Cipher.GetInstance(this.GetCipherAcquisitionName().ToString(), "BC");
                     newCipher = true;
                 }
 

--- a/src/PCLCrypto.Shared.Common/CryptoStream.cs
+++ b/src/PCLCrypto.Shared.Common/CryptoStream.cs
@@ -161,7 +161,13 @@ namespace PCLCrypto
         public void FlushFinalBlock()
         {
             byte[] final = this.transform.TransformFinalBlock(this.inputBuffer, 0, this.inputBufferSize);
-            this.chainedStream.Write(final, 0, final.Length);
+
+            // Android 6.0 may return a null value when inputBufferSize == 0.
+            if (final != null)
+            {
+                this.chainedStream.Write(final, 0, final.Length);
+            }
+
             this.HasFlushedFinalBlock = true;
 
             // Propagate to the inner stream, as appropriate.


### PR DESCRIPTION
Explicitly request the BouncyCastle provider, at least until we understand why AndroidOpenSSL is throwing `ShortBufferException` in some failing tests and how to avoid it.

Close #61