### PR TITLE
[android] workaround to fix invalid PCLCrypto assembly

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,8 +1,8 @@
 <Project>
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <OutputPath>$(MSBuildThisFileDirectory)../bin/$(MSBuildProjectName)/$(Configuration)/</OutputPath>
-    <BaseIntermediateOutputPath>$(MSBuildThisFileDirectory)../obj/$(MSBuildProjectName)/</BaseIntermediateOutputPath>
+    <OutputPath>$(MSBuildThisFileDirectory)..\bin\$(MSBuildProjectName)\$(Configuration)\</OutputPath>
+    <BaseIntermediateOutputPath>$(MSBuildThisFileDirectory)..\obj\$(MSBuildProjectName)\</BaseIntermediateOutputPath>
 
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 


### PR DESCRIPTION
Fixes #138

Unfortunately, you will need to submit a new release to NuGet with this fix.

I have submitted fixes to Xamarin.Android itself regarding this issue: https://github.com/xamarin/xamarin-android/pull/1852